### PR TITLE
Add tree sitter lalrpop

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,6 +94,7 @@ Parsers for these languages are in development:
 * [Sourcepawn](https://github.com/nilshelmig/tree-sitter-sourcepawn)
 * [Swift](https://github.com/tree-sitter/tree-sitter-swift)
 * [SQL](https://github.com/m-novikov/tree-sitter-sql)
+* [LALRPOP](https://github.com/traxys/tree-sitter-lalrpop)
 
 
 ### Talks on Tree-sitter


### PR DESCRIPTION
This is a parser for https://github.com/lalrpop/lalrpop, a parser generator for use in Rust.

It is still in development because it should support some kind of highlighting of the pseudo rust code used in rules.